### PR TITLE
Change Jetty host binding from 127.0.0.1 to 0.0.0.0 for fleetman-queue

### DIFF
--- a/microservice-source-code/release1/k8s-fleetman-queue/Dockerfile
+++ b/microservice-source-code/release1/k8s-fleetman-queue/Dockerfile
@@ -5,6 +5,8 @@ MAINTAINER Richard Chesterwood "richard@inceptiontraining.co.uk"
 RUN yum install -y which wget gzip tar && wget -O activemq.tar.gz http://archive.apache.org/dist/activemq/5.17.3/apache-activemq-5.17.3-bin.tar.gz
      
 RUN tar -xzf activemq.tar.gz
+
+RUN sed -i 's/127\.0\.0\.1/0.0.0.0/g' /apache-activemq-5.17.3/conf/jetty.xml
     
 ENV JAVA_HOME=/usr/bin/
      

--- a/microservice-source-code/release2/k8s-fleetman-queue/Dockerfile
+++ b/microservice-source-code/release2/k8s-fleetman-queue/Dockerfile
@@ -5,6 +5,8 @@ MAINTAINER Richard Chesterwood "richard@inceptiontraining.co.uk"
 RUN yum install -y which wget gzip tar && wget -O activemq.tar.gz http://archive.apache.org/dist/activemq/5.17.3/apache-activemq-5.17.3-bin.tar.gz
      
 RUN tar -xzf activemq.tar.gz
+
+RUN sed -i 's/127\.0\.0\.1/0.0.0.0/g' /apache-activemq-5.17.3/conf/jetty.xml
     
 ENV JAVA_HOME=/usr/bin/
      


### PR DESCRIPTION
Changed Jetty host binding from 127.0.0.1 to 0.0.0.0 to enable external access to ActiveMQ console

Without this change, the ActiveMQ console is only available to localhost inside the container, requiring kubectl port-forward for access. This fix allows direct access through NodePort services